### PR TITLE
fix(eslint-plugin-query): update FlatConfig to Config due to deprecation

### DIFF
--- a/packages/eslint-plugin-query/src/index.ts
+++ b/packages/eslint-plugin-query/src/index.ts
@@ -8,7 +8,7 @@ export interface Plugin extends Omit<ESLint.Plugin, 'rules'> {
   rules: Record<RuleKey, RuleModule<any, any, any>>
   configs: {
     recommended: ESLint.ConfigData
-    'flat/recommended': Array<Linter.FlatConfig>
+    'flat/recommended': Array<Linter.Config>
   }
 }
 


### PR DESCRIPTION
During raising https://github.com/TanStack/query/pull/8584 PR, I checked that FlatConfig is deprecated so I changed to Config type